### PR TITLE
fix(CacheModule): provide CACHE_MODULE_CONFIG using Value instead of Factory #1

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export class CacheModule {
     return {
       ngModule: CacheModule,
       providers: [
-        { provide: CACHE_MODULE_CONFIG, useFactory: () => config || CACHE_MODULE_DI_CONFIG },
+        { provide: CACHE_MODULE_CONFIG, useValue: config || CACHE_MODULE_DI_CONFIG },
         CacheService
       ]
     };


### PR DESCRIPTION
Prior to this change building with AOT throws error:
```
ERROR in Error during template compile of 'CoreModule'
  Function expressions are not supported in decorators in 'CacheModule'
    'CacheModule' contains the error at src\index.ts(13,53)
      Consider changing the function expression into an exported function.
```
This PR resolves issue #1 